### PR TITLE
Make sure it works with an empty fonts array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ const createLink = (fonts, subsets, display) => {
         ];
     }, []).join('|');
 
+    if (families.length === 0) {
+        return null;
+    }
+    
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = `https://fonts.googleapis.com/css?family=${families}`;
@@ -31,9 +35,15 @@ const GoogleFontLoader = ({ fonts, subsets, display = null }) => {
     const [link, setLink] = useState(createLink(fonts, subsets, display));
 
     useEffect(() => {
-        document.head.appendChild(link);
+        if (link) {         
+            document.head.appendChild(link);
+        }
 
-        return () => document.head.removeChild(link);
+        return () => {
+            if(link) { 
+                document.head.removeChild(link);
+            }
+        }
     }, [link]);
 
     useEffect(() => {


### PR DESCRIPTION
Currently, it inserts link with src like this: "https://fonts.googleapis.com/css?family="